### PR TITLE
docs(governance): switch to main + feature branch topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ kdx
 __pycache__/
 *.pyc
 .env
+token.txt
 .vscode/
 .idea/
 *.log
@@ -91,3 +92,9 @@ yarn-error.log*
 
 # Idea
 .idea/
+
+# Internal process assets (private)
+.autodev/
+AGENT_TEAMS.md
+SCRUM_AGENTS.md
+week_sprint.log

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ Recommended workflow:
 
 - `main`
 - `feature/*`
-- `release/*`
-- `hotfix/*`
 
 Detailed strategy: `docs/dev/branching-strategy.md`
+Feature branch catalog: `docs/dev/feature-branch-catalog.md`
 
 ## Project Status
 

--- a/docs/dev/branching-strategy.md
+++ b/docs/dev/branching-strategy.md
@@ -1,18 +1,45 @@
 # Branching Strategy
 
-KodPix uses a lightweight professional flow:
+KodPix now uses a strict two-tier model:
 
-- `main`: production-ready branch, protected
-- `feature/<topic>`: isolated feature work
-- `release/<version>`: release hardening and documentation freeze
-- `hotfix/<topic>`: urgent fixes from `main`
+- `main`: only protected integration branch
+- `feature/<scope>-<topic>`: all implementation work
 
-## Merge Rules
+No long-lived `release/*` or `hotfix/*` branches are used in the public flow.
 
-- Pull request required for `main`
-- Required status checks must pass
-- At least one approval before merge
-- No force push, no branch deletion on protected branch
+## Branch Rules
+
+- `main` only receives pull-request merges
+- required CI checks must be green before merge
+- at least one approval is mandatory
+- no force push to `main`
+- each task uses a dedicated `feature/*` branch
+- merge and delete feature branch when completed
+
+## Agent Branch Slots
+
+Reserved feature branches for parallel execution:
+
+- `feature/parser-core`
+- `feature/codegen-abi`
+- `feature/compiler-pipeline`
+- `feature/language-spec`
+- `feature/qa-regression`
+- `feature/reliability-runtime`
+- `feature/perf-memory`
+- `feature/security-hardening`
+- `feature/devops-ci-cd`
+- `feature/release-automation`
+- `feature/webdocs-site`
+- `feature/tooling-quality`
+
+Additional feature branches can be created at any time to increase throughput.
+
+## Remote Hygiene
+
+- keep only `main` and `feature/*` branches on origin
+- remove stale non-feature branches immediately
+- prune merged feature branches regularly
 
 ## Commit Convention
 
@@ -24,8 +51,7 @@ Use Conventional Commits:
 
 ## Release Flow
 
-1. Create `release/x.y.z` from `main`
-2. Run full gates (`build`, `test`, quick/spec/oracle/flaky/security)
-3. Update release notes and docs
-4. Merge to `main`
-5. Create tag `vX.Y.Z`
+1. stabilize target work on one or more `feature/*` branches
+2. validate full gates in CI
+3. merge approved PRs into `main`
+4. create tag `vX.Y.Z` from `main`

--- a/docs/dev/feature-branch-catalog.md
+++ b/docs/dev/feature-branch-catalog.md
@@ -1,0 +1,32 @@
+# Feature Branch Catalog
+
+This catalog defines the default parallel lanes for active development.
+
+## Active Reserved Branches
+
+- `feature/parser-core` - parser and syntax evolution
+- `feature/codegen-abi` - assembly emission and ABI behavior
+- `feature/compiler-pipeline` - compile flow, flags, and I/O integration
+- `feature/language-spec` - language docs and compatibility alignment
+- `feature/qa-regression` - regression coverage and deterministic checks
+- `feature/reliability-runtime` - soak, flake, and crash resilience
+- `feature/perf-memory` - performance and memory optimization
+- `feature/security-hardening` - security controls and secret hygiene
+- `feature/devops-ci-cd` - CI policy, branch protection, merge automation
+- `feature/release-automation` - release packaging and publication flow
+- `feature/webdocs-site` - docs rendering and site delivery
+- `feature/tooling-quality` - tooling, scripts, and developer ergonomics
+
+## Naming Contract
+
+- format: `feature/<scope>-<topic>`
+- keep names short and explicit
+- create new branches freely when workload increases
+
+## Lifecycle
+
+1. branch from `main`
+2. implement in small commits
+3. open PR to `main`
+4. merge after review and checks
+5. delete merged branch


### PR DESCRIPTION
## Summary
- enforce a strict branch topology with main plus feature-only branches
- add a feature branch catalog for parallel agent lanes
- add ignore rules for internal private process assets (.autodev, agent docs, local logs)

## Operational impact
- keeps GitHub branch surface aligned with your requested model
- increases parallel execution capacity with dedicated feature branches for each lane